### PR TITLE
Fix misspelled function name

### DIFF
--- a/lib/Future/IO/Impl/Uring.pm
+++ b/lib/Future/IO/Impl/Uring.pm
@@ -132,7 +132,7 @@ sub syswrite($self, $fh, $buffer) {
 	return $future;
 }
 
-sub _subwrite($future, $fh, $buffer, $written) {
+sub _syswrite($future, $fh, $buffer, $written) {
 	$ring->write($fh, $buffer, -1, sub($res, $flags) {
 		if ($res > 0) {
 


### PR DESCRIPTION
This is from reading the code only, but by symmetry, the subroutine should be named _syswrite , and is also called under that name from syswrite_exactly()